### PR TITLE
fix: exclude release notes from MCP server's search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magicpod-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magicpod-mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.33.1",
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/src/tools/search-magicpod-articles.ts
+++ b/src/tools/search-magicpod-articles.ts
@@ -38,12 +38,14 @@ export const searchMagicpodArticles = () => {
       const response = await makeRequest(query, locale);
       // The response has "body" field, but it is too large for LLM
       // So, such large or insignificant fields are filtered here
-      response.results = response.results.map((r: any) => ({
-        id: r.id,
-        title: r.title,
-        content_tag_ids: r.content_tag_ids,
-        label_names: r.label_names,
-      }));
+      response.results = response.results
+        .filter((r: any) => (!(r.label_names && r.label_names.includes('release'))))
+        .map((r: any) => ({
+          id: r.id,
+          title: r.title,
+          content_tag_ids: r.content_tag_ids,
+          label_names: r.label_names,
+        }));
       return {
         content: [
           {


### PR DESCRIPTION
[#21804](https://github.com/magicpod-internal/magicpod/issues/21804)

Excludes release notes from results when agent searches for documents using the API.

<img width="759" height="418" alt="スクリーンショット 2025-08-22 17 08 27" src="https://github.com/user-attachments/assets/f9d5de4b-49d0-4dca-b864-c0abdbe9a6a0" />

@magicpod-internal/new-feature-1