### PR TITLE
fix: replace native fetch() with axios to respect HTTP_PROXY

### DIFF
--- a/src/tools/magicpod-web-api.ts
+++ b/src/tools/magicpod-web-api.ts
@@ -4,14 +4,12 @@ import {
   OtherToolDefinition,
 } from "../openapi-mcp-server/mcp/proxy.js";
 import swagger2openapi from "swagger2openapi";
+import axios from "axios";
 
 const getOpenApiSpec = async (schemaUrl: string): Promise<OpenAPIV3.Document> => {
   try {
-    const response = await fetch(schemaUrl);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    const openApiV2Spec = await response.json() as OpenAPIV2.Document;
+    const response = await axios.get(schemaUrl);
+    const openApiV2Spec = response.data as OpenAPIV2.Document;
     return new Promise((resolve, reject) => {
       swagger2openapi.convertObj(openApiV2Spec, {}, (err, options) => {
         if (err) {

--- a/src/tools/read-magicpod-article.ts
+++ b/src/tools/read-magicpod-article.ts
@@ -1,17 +1,16 @@
 import { z } from "zod";
 import { OtherToolDefinition } from "../openapi-mcp-server/mcp/proxy.js";
+import axios from "axios";
 
 const makeRequest = async (articleId: string, locale: "ja" | "en-us") => {
-  const headers = {
-    Accept: "application/json",
-  };
   try {
     const url = `https://trident-qa.zendesk.com/api/v2/help_center/${locale}/articles/${articleId}.json`;
-    const response = await fetch(url, { headers });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return await response.json();
+    const response = await axios.get(url, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    return response.data;
   } catch (error) {
     console.error("Error making request:", error);
     return null;

--- a/src/tools/search-magicpod-articles.ts
+++ b/src/tools/search-magicpod-articles.ts
@@ -1,17 +1,16 @@
 import { z } from "zod";
 import { OtherToolDefinition } from "../openapi-mcp-server/mcp/proxy.js";
+import axios from "axios";
 
 const makeRequest = async (query: string, locale: "ja" | "en-us") => {
-  const headers = {
-    Accept: "application/json",
-  };
   try {
     const url = `https://trident-qa.zendesk.com/api/v2/help_center/articles/search.json?query=${query}&locale=${locale}`;
-    const response = await fetch(url, { headers });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return await response.json();
+    const response = await axios.get(url, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    return response.data;
   } catch (error) {
     console.error("Error making request:", error);
     return null;


### PR DESCRIPTION
Resolves https://github.com/magicpod-internal/magicpod/issues/21685

This pull request replaces native fetch() with axios to respect HTTP_PROXY

With `mitmproxy` set up at `localhost:8080` and environment variables all set up, I have verified that the network traffic went through the proxy for fetching schema and for searching through the articles:

https://github.com/user-attachments/assets/2d463eab-c5b9-4d8a-960d-83a22cc10127

