### PR TITLE
fix: upgrade `form-data==4.0.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/mustache": "^4.2.5",
         "axios": "^1.8.4",
         "commander": "^13.1.0",
-        "form-data": "^4.0.2",
+        "form-data": "^4.0.4",
         "json-schema": "^0.4.0",
         "mustache": "^4.2.0",
         "openai": "^4.91.1",
@@ -756,14 +756,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/mustache": "^4.2.5",
     "axios": "^1.8.4",
     "commander": "^13.1.0",
-    "form-data": "^4.0.2",
+    "form-data": "^4.0.4",
     "json-schema": "^0.4.0",
     "mustache": "^4.2.0",
     "openai": "^4.91.1",


### PR DESCRIPTION
Address https://github.com/Magic-Pod/magicpod-mcp-server/security/dependabot/1

## What I have checked

I have confirmed the `API-v1_0_upload-file_create` tool works after the upgrade:

<img width="1010" height="332" alt="Screenshot 2025-09-04 at 16 39 09" src="https://github.com/user-attachments/assets/ba51c831-e41c-4efe-a515-367cdbb4d966" />
