### PR TITLE
build: upgrade qs to 6.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1610,9 +1610,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "hono": "^4.12.18",
     "@hono/node-server": "^2.0.0",
     "fast-uri": "^3.1.2",
-    "ip-address": "^10.2.0"
+    "ip-address": "^10.2.0",
+    "qs": "^6.15.2"
   }
 }


### PR DESCRIPTION
Overrides qs version since it is a transitive dependency. I tested and confirmed that the MCP server works properly after the upgrade.