### PR TITLE
build: bump hono to 4.12.21 to address security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.15.2",
         "commander": "^13.1.0",
         "form-data": "^4.0.4",
+        "hono": "^4.12.21",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "json-schema": "^0.4.0",
@@ -1052,9 +1053,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Dependabot reported a security vulnerability in `hono`, which is a transitive dependency pulled in by `@modelcontextprotocol/sdk`. 
The resolved version was 4.12.18, which contains the vulnerability. 
This PR updates the lockfile to resolve `hono` to 4.12.21 where the vulnerability is patched.

- https://github.com/Magic-Pod/magicpod-mcp-server/security/dependabot/52
- https://github.com/Magic-Pod/magicpod-mcp-server/security/dependabot/53
- https://github.com/Magic-Pod/magicpod-mcp-server/security/dependabot/54
- https://github.com/Magic-Pod/magicpod-mcp-server/security/dependabot/55

https://github.com/honojs/hono/releases/tag/v4.12.21

